### PR TITLE
Mocking other templates and skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+## 0.2.0 - July 9, 2015
+
+### Added
+- Unit test for Jinja2 template handling
+- Mocking of other templates and macros
+- Test skipping
+
 ## 0.1.0 - March 9, 2015
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ this:
 ```json
 {
     "macro_name": "<a macro>",
+    "skip": <true or false>,
     "arguments": [ ... ],
     "keyword_arguments": { ... },
     "context": {
@@ -265,6 +266,8 @@ this:
 
 **`macro_name`** is simply the name of the macro within the file in which it
 is defined.
+
+**`skip`**, if true, will skip the macro test. This is optional.
 
 **`arguments`** is a list of arguments to pass to the macro in the order
 they are given. This is optional.

--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ this:
         "<function name>": ["<first call mock value>",
                             "<second call mock value>", ...]
     },
+    "templates": {
+        "<template file>": {
+            "<macro name>(<arguments>)": "<mock value>",
+            "<macro name>()": ["<first call mock value>",
+                            "<second call mock value>", ...]
+        }
+    },
     "assertions": [
         {
             "selector": "<css selector>",
@@ -293,6 +300,15 @@ mocking:
 - `more_like_this`
 - `get_document`
 
+**`templates`** is an object that is used to mock included template
+macros called from within the macro being tested. It works the same 
+way that `filters` and `context_functions` do above, with the values 
+either being a return value for all calls or a list of return values 
+for each call.  The `<macro name>` should include parenthesis and any 
+arguments the template's macro takes. This will override *the entire 
+`<template file>`*, so make sure to mock all of its macros.  This is 
+optional.
+
 **`assertions`** defines the assertions to make about the result of
 rendering the macro. Assertion definitions take a CSS `selector`, an 
 `index` in the list of matches for that selector (default is `0`), an 
@@ -319,8 +335,8 @@ case in Python.
 ```python
 class MyMacrosTestCase(MyBaseTestCase):
     def test_a_macro(self):
-        mock_filter(...)
-        mock_context_function(...)
+        self.mock_filter(...)
+        self.mock_context_function(...)
         result = self.render_macro('mymacros.html', 'amacro')
         assert 'something' in result.select('.css-selector')[0]
 ````

--- a/README.md
+++ b/README.md
@@ -53,8 +53,14 @@ $ pip install -r requirements.txt
   template filters and context (and unit testing Macro Polo itself)
 
 Template Systems/Environments:
+
 - [Jinja2](http://jinja.pocoo.org/)
 - [Sheer](https://github.com/cfpb/sheer)
+
+These are not installed by `pip`. It is expected that if you are using
+these template environments you have them installed already. If not,
+their respective [environment mixins](#template-environment-mixins) will 
+not be available.
 
 ## Installation
 

--- a/macropolo/environments/jinja2_env.py
+++ b/macropolo/environments/jinja2_env.py
@@ -6,7 +6,9 @@ import os
 # macros
 from bs4 import BeautifulSoup
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment
+from jinja2 import ChoiceLoader, FileSystemLoader, DictLoader
+
 
 class Jinja2Environment(object):
     """
@@ -19,24 +21,18 @@ class Jinja2Environment(object):
         """
         search_root = self.search_root()
         search_exceptions = self.search_exceptions()
-        search_paths = [x[0] for x in os.walk(search_root)
-                        if not x[0].startswith('_') or x[0].startswith('.') or
-                            x[0] in search_exceptions]
-
-        self.env = Environment(loader=FileSystemLoader(search_paths))
-
-        # This is our template context. You can use mock_context_function()
-        # below to mock context functions, or you can add values to this
-        # dictionary directly.
+        self.search_paths = [x[0] for x in os.walk(search_root)
+                                if not x[0].startswith('_') or x[0].startswith('.') or
+                                    x[0] in search_exceptions]
+        self.filters = {}
         self.context = {}
-
+        self.templates = {}
 
     def add_filter(self, name, filter):
         """
         Add the given filter to the template environment.
         """
-        self.env.filters[name] = filter
-
+        self.filters[name] = filter
 
     def add_context(self, name, value):
         """
@@ -44,6 +40,14 @@ class Jinja2Environment(object):
         """
         self.context[name] = value
 
+    def add_template_macro(self, name, macro_name, contents):
+        """
+        Add the given name as a template in the environment with the
+        given macro name and contents.
+        """
+        if name not in self.templates:
+            self.templates[name] = {}
+        self.templates[name][macro_name] = contents
 
     def render_macro(self, macro_file, macro, *args, **kwargs):
         """
@@ -54,6 +58,27 @@ class Jinja2Environment(object):
         calls the macro and renders that template and returns the
         result.
         """
+
+        # Add our mock templates to the template dict
+        mock_templates = {}
+        for name in self.templates:
+            macros = []
+            for macro_name in self.templates[name]:
+                m = """ 
+                    {{% macro {macro_name} %}}{macro_contents}{{% endmacro %}}
+                """.format(macro_name=macro_name, 
+                        macro_contents=self.templates[name][macro_name])
+                macros.append(m)
+            mock_templates[name] = "\n".join(macros)
+
+        # Build an environment 
+        fs_loader = FileSystemLoader(self.search_paths)
+        mock_template_loader = DictLoader(mock_templates)
+        self.env = Environment(loader=ChoiceLoader(
+            [mock_template_loader, fs_loader]))
+        for f in self.filters:
+            self.env.filters[f] = self.filters[f]
+
         # We need to format args and kwargs as string arguments for the macro.
         # After that we combine them. filter() is used in case one or the other
         # strings is empty, ''.
@@ -62,7 +87,10 @@ class Jinja2Environment(object):
         str_combined = u', '.join(filter(None, [str_args, str_kwargs]))
 
         # Here is our test template that uses the macro.
-        test_template_str = u'''{%% import "%s" as macro_file %%}{{ macro_file.%s(%s) }}''' % (macro_file, macro, str_combined)
+        test_template_str = u'''
+            {{% import "{macro_file}" as m with context %}}
+            {{{{m.{macro}({args}) }}}}
+        '''.format(macro_file=macro_file, macro=macro, args=str_combined)
         test_template = self.env.from_string(test_template_str)
 
         result = test_template.render(self.context)

--- a/macropolo/environments/sheer_env.py
+++ b/macropolo/environments/sheer_env.py
@@ -21,9 +21,9 @@ class SheerEnvironment(Jinja2Environment):
         # macro-by-macro basis. Using lambdas here for brevity.
         # XXX: We should change Sheer to make it easier to replicate its
         # environment.
-        self.env.filters['date'] = lambda value, format="%Y-%m-%d": \
-            date_formatter(value, format)
-        self.env.filters['markdown'] = lambda raw_text: \
+        self.filters['date'] = lambda value, format="%Y-%m-%d", \
+                tz="America/New_York": date_formatter(value, format)
+        self.filters['markdown'] = lambda raw_text: \
             markdown.markdown(raw_text)
 
 

--- a/macropolo/jsonspec.py
+++ b/macropolo/jsonspec.py
@@ -165,10 +165,13 @@ def JSONSpecTestCaseFactory(name, super_class, json_file, mixins=[]):
     for t in spec['tests']:
         # Create the test method and add it to the class dictionary
         macro_name = t['macro_name']
-
         method_name = 'test_' + str(spec['tests'].index(t)) + macro_name
-
         test_method = create_test_method(macro_file, macro_name, t)
+
+        if t.get('skip', False):
+            test_method = unittest.skip(
+                    "skipping {}".format(macro_name))(test_method)
+
         newclass_dict[method_name] = test_method
 
     # Create and return the new class.

--- a/macropolo/jsonspec.py
+++ b/macropolo/jsonspec.py
@@ -34,6 +34,13 @@ def JSONSpecTestCaseFactory(name, super_class, json_file, mixins=[]):
                 "<function name>": ["<first call mock value>",
                                     "<second call mock value>", ...]
             },
+            "templates": {
+                "<template file>: {
+                    "<macro name>": "<mock value>",
+                    "<macro name>"": ["<first call mock value>",
+                                    "<second call mock value>", ...]
+                }
+            },
             "assertions": [
                 {
                     "selector": "<css selector>",
@@ -51,8 +58,8 @@ def JSONSpecTestCaseFactory(name, super_class, json_file, mixins=[]):
     a value for comparison (if necessary for the assertion), and, if
     necessary, the attribute on the selected element to compare to.
 
-    "arguments", "keyword_arguments", "filters", and
-    "context_functions" are optional.
+    "arguments", "keyword_arguments", "filters", "context_functions", 
+    and "template" are optional.
 
     Assertions can be any of the following:
         * equal
@@ -101,6 +108,9 @@ def JSONSpecTestCaseFactory(name, super_class, json_file, mixins=[]):
             [self.mock_filter(f, v) for f,v in filters.items()]
             context_functions = test_dict.get('mock_context_functions', {})
             [self.mock_context_function(f, v) for f,v in context_functions.items()]
+            templates = test_dict.get('templates', {})
+            [[self.mock_template_macro(n, m, c) for m, c in d.items()] 
+                    for n, d in templates.items()]
 
             # Render the macro from the macro file with the given
             # arguments
@@ -141,7 +151,11 @@ def JSONSpecTestCaseFactory(name, super_class, json_file, mixins=[]):
         return test_method
 
     # Open and read the JSON spec file
-    spec = uniconvert(json.loads(open(json_file).read()))
+    try:
+        spec = uniconvert(json.loads(open(json_file).read()))
+    except ValueError as e:
+        e.args += (' in ' + json_file,)
+        raise
 
     # This will be our new class's dict containing all its methods, etc
     newclass_dict = {}

--- a/macropolo/macrotestcase.py
+++ b/macropolo/macrotestcase.py
@@ -33,7 +33,6 @@ class MacroTestCaseMixin(object):
         """
         raise NotImplementedError("please mixin an environment class")
 
-
     def render_macro(self, macro_file, macro, *args, **kwargs):
         """
         Render a given macro with the given arguments and keyword
@@ -41,13 +40,11 @@ class MacroTestCaseMixin(object):
         """
         raise NotImplementedError("please mixin an environment class")
 
-
     def add_filter(self, name, filter):
         """
         Add the given filter to the template environment.
         """
         raise NotImplementedError("please mixin an environment class")
-
 
     def add_context(self, name, value):
         """
@@ -55,30 +52,35 @@ class MacroTestCaseMixin(object):
         """
         raise NotImplementedError("please mixin an environment class")
 
+    def add_template_macro(self, name, macro_name, contents):
+        """
+        Add the given name as a template in the environment with the
+        given macro name and contents.
+        """
+        raise NotImplementedError("please mixin an environment class")
 
     def search_root(self):
         """
         Return the root of the search path for templates.
         """
-        raise NotImplementedError("please provide a search_root() in your MacroTestCase subclass")
-
+        raise NotImplementedError("please provide a search_root() in "
+                "your MacroTestCase subclass")
 
     def search_exceptions(self):
         """
         Return a list of a subdirectory names that should not be searched
         for templates.
         """
-        raise NotImplementedError("please provide a search_root() in your MacroTestCase subclass")
-
+        raise NotImplementedError("please provide a self.search_exceptions() "
+                "in your MacroTestCase subclass")
 
     def setUp(self):
         self.setup_environment()
 
-
     def mock_filter(self, filter, *values):
         """
         Mock a template filter. This will create a mock function for the
-        filter that will return either a single value, or will return
+        filter that will return either a single value or will return
         each of the given values in turn if there are more than one.
 
         Sheer filters you might want to mock:
@@ -95,11 +97,10 @@ class MacroTestCaseMixin(object):
 
         self.add_filter(filter, mock_filter)
 
-
     def mock_context_function(self, func, *values):
         """
         Mock a context function. This will create a mock function that
-        will return either a single value, or will return each of the
+        will return either a single value or will return each of the
         given values in turn if there are more than one.
 
         Sheer context functions you might want to mock:
@@ -116,6 +117,13 @@ class MacroTestCaseMixin(object):
 
         self.add_context(func, mock_func)
 
+    def mock_template_macro(self, name, macro_name, contents):
+        """
+        Mock calls to a macro in another template. 
+        
+        Implementation details may varry between templating systems.
+        """
+        self.add_template_macro(name, macro_name, contents)
 
     def make_assertion(self, result, selector, index=0,
                        value=None, assertion='exists', attribute=''):
@@ -139,7 +147,8 @@ class MacroTestCaseMixin(object):
                 try:
                     selection_value = selection[index].get(attribute)[0]
                 except TypeError:
-                    raise AssertionError("attribute '%s' does not exist or is empty" % attribute)
+                    raise AssertionError("attribute '%s' does not exist "
+                            "or is empty" % attribute)
         except IndexError:
             selection_value = ''
 

--- a/macropolo/tests/test_jinja2_env.py
+++ b/macropolo/tests/test_jinja2_env.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import mock
+from StringIO import StringIO
+
+from macropolo import MacroTestCaseMixin
+from macropolo.environments import Jinja2Environment
+
+# This is a TestCase-like class based on Jinja2Environment and
+# MacroTestCaseMixin to use to test specific macros. This doesn't use
+# MacroTestCase itself to avoid confusing Python's unittest module.
+class Jinja2MacroTestCase(Jinja2Environment, MacroTestCaseMixin):
+    """
+    A subclass to test Jinja2Environment.
+    """
+
+    def search_root(self):
+        return "."
+
+    def search_exceptions(self):
+        return None
+
+
+class Jinja2EnvironmentTestCase(unittest.TestCase):
+    """
+    Tests for the Jinja2Environment for macro test cases
+    """
+
+    @mock.patch('os.walk')
+    @mock.patch('jinja2.FileSystemLoader.get_source')
+    def test_basic_macro(self, mock_loader_get_source, mock_os_walk):
+        """ 
+        Test a basic Jinja2 macro
+        """
+
+        # The Jinja2 macro to test.
+        macro_string = """
+            {% macro test_macro() %}
+                Hello World!
+            {% endmacro %}
+        """
+
+        # Mock os.walk, which Jinja2Environment uses to generate a list
+        # of search paths.
+        mock_os_walk.return_value = [
+                    ('/', (), 'macro.html')
+                ]
+        # Mock FileSystemLoader.get_source to return our macro_string
+        mock_loader_get_source.return_value = \
+                (macro_string, 'macro.html', None)
+
+        # Initialize the test case
+        test_case = Jinja2MacroTestCase()
+        test_case.setUp()
+
+        # Render the template
+        # test_case.mock_filter()
+        # test_case.mock_context()
+        # test_case.mock_context_function()
+        result = test_case.render_macro('macro.html', 'test_macro')
+        assert 'Hello World' in result.text
+
+    @mock.patch('os.walk')
+    @mock.patch('jinja2.FileSystemLoader.get_source')
+    def test_macro_with_filter(self, mock_loader_get_source, mock_os_walk):
+        """ 
+        Test a Jinja2 macro with a filter
+        """
+
+        # The Jinja2 macro to test.
+        macro_string = """
+            {% macro test_macro() %}
+                Hello {{ "America"|internationalize }}!
+            {% endmacro %}
+        """
+
+        # Mock os.walk, which Jinja2Environment uses to generate a list
+        # of search paths.
+        mock_os_walk.return_value = [
+                    ('/', (), 'macro.html')
+                ]
+        # Mock FileSystemLoader.get_source to return our macro_string
+        mock_loader_get_source.return_value = \
+                (macro_string, 'macro.html', None)
+
+        # Initialize the test case
+        test_case = Jinja2MacroTestCase()
+        test_case.setUp()
+
+        # Create a mock filter
+        test_case.mock_filter('internationalize', 'World')
+
+        result = test_case.render_macro('macro.html', 'test_macro')
+        assert 'Hello World' in result.text
+
+    @mock.patch('os.walk')
+    @mock.patch('jinja2.FileSystemLoader.get_source')
+    def test_macro_with_context(self, mock_loader_get_source, mock_os_walk):
+        """ 
+        Test a Jinja2 macro with context 
+        """
+
+        # The Jinja2 macro to test.
+        macro_string = """
+            {% macro test_macro() %}
+                Hello {{ who }} !
+            {% endmacro %}
+        """
+
+        # Mock os.walk, which Jinja2Environment uses to generate a list
+        # of search paths.
+        mock_os_walk.return_value = [
+                    ('/', (), 'macro.html')
+                ]
+        # Mock FileSystemLoader.get_source to return our macro_string
+        mock_loader_get_source.return_value = \
+                (macro_string, 'macro.html', None)
+
+        # Initialize the test case
+        test_case = Jinja2MacroTestCase()
+        test_case.setUp()
+
+        # Add a value to the context
+        test_case.add_context('who', 'World')
+
+        result = test_case.render_macro('macro.html', 'test_macro')
+        assert 'Hello World' in result.text
+
+    @mock.patch('os.walk')
+    @mock.patch('jinja2.FileSystemLoader.get_source')
+    def test_macro_with_context_func(self, mock_loader_get_source, mock_os_walk):
+        """ 
+        Test a Jinja2 macro with context 
+        """
+        # Test a simple context function
+        macro_string = """
+            {% macro test_macro() %}
+                Hello {{ who() }}!
+            {% endmacro %}
+        """
+    
+        # Test calling a macro from another file
+        namespaced_other_macro_macro_string = """
+            {% macro test_macro() %}
+                {% import "somefile" as somefile with context %}
+                Hello {{ somefile.somemacro() }}!
+            {% endmacro %}
+        """
+        
+        # Mock os.walk, which Jinja2Environment uses to generate a list
+        # of search paths.
+        mock_os_walk.return_value = [
+                    ('/', (), 'macro.html')
+                ]
+        # Mock FileSystemLoader.get_source to return our macro_string
+        mock_loader_get_source.return_value = \
+                (macro_string, 'macro.html', None)
+
+        # Initialize the test case
+        test_case = Jinja2MacroTestCase()
+        test_case.setUp()
+
+        # Add a context function value
+        test_case.mock_context_function('who', 'America')
+
+        result = test_case.render_macro('macro.html', 'test_macro')
+        assert 'Hello America' in result.text
+
+    @mock.patch('os.walk')
+    @mock.patch('jinja2.FileSystemLoader.get_source')
+    def test_macro_with_another_template(self, mock_loader_get_source, mock_os_walk):
+        """
+        Test a Jinja2 Macro that loads another macro.
+        """
+
+        # Test a simple context function
+        macro_string = """
+            {% macro test_macro() %}
+                {% import "who.html" as who with context %}
+                Hello {{who.america() }} & {{ who.international() }}!
+            {% endmacro %}
+        """
+    
+        # Mock os.walk, which Jinja2Environment uses to generate a list
+        # of search paths.
+        mock_os_walk.return_value = [
+                    ('/', (), 'macro.html')
+                ]
+        # Mock FileSystemLoader.get_source to return our macro_string
+        mock_loader_get_source.return_value = \
+                (macro_string, 'macro.html', None)
+
+        # Initialize the test case
+        test_case = Jinja2MacroTestCase()
+        test_case.setUp()
+
+        # Mock a template macro.
+        test_case.mock_template_macro("who.html", "america()", "America")
+        test_case.mock_template_macro("who.html", "international()", "World")
+
+        result = test_case.render_macro('macro.html', 'test_macro')
+        assert 'America' in result.text
+        assert 'World' in result.text
+
+

--- a/macropolo/tests/test_macrotestcase.py
+++ b/macropolo/tests/test_macrotestcase.py
@@ -12,8 +12,8 @@ class MacroTestCaseTestCase(unittest.TestCase):
 
     def test_mock_filter(self):
         """
-        Test that mock_filter appropriate returns a mock filter with
-        either a single return value or a set of side effects.
+        Test that mock_filter returns a mock filter with either a single
+        return value or a set of side effects.
         """
         # mock_filter() calls the add_filter() method which is defined by
         # environments. Mock that method and we'll get the filter to
@@ -42,12 +42,10 @@ class MacroTestCaseTestCase(unittest.TestCase):
         self.assertEqual(call_args[1](), '3')
         self.assertEqual(call_args[1](), '4')
 
-
     def test_mock_context_function(self):
         """
-        Test that mock_context_function appropriate returns a mock
-        context function with either a single return value or a set
-        of side effects.
+        Test that mock_context_function returns a mock context function
+        with either a single return value or a set of side effects.
         """
         # mock_context_function() calls the add_context() method which
         # is defined by environments. Mock that method and we'll get
@@ -75,7 +73,6 @@ class MacroTestCaseTestCase(unittest.TestCase):
         self.assertEqual(call_args[1](), '2')
         self.assertEqual(call_args[1](), '3')
         self.assertEqual(call_args[1](), '4')
-
 
     def test_make_assertion(self):
         """


### PR DESCRIPTION
This PR adds support for mocking other templates' macros and for skipping macro tests.

Other templates and their macros can now be mocked in the JSON spec file in the same way that context functions can be mocked:

``` json
    "templates": {
        "<template file>": {
            "<macro name>(<arguments>)": "<mock value>",
            "<macro name>()": ["<first call mock value>",
                            "<second call mock value>", ...]
        }
    },
```

Macro names must include the parenthesis and any arguments. Because of the way Jinja2 loads templates, this will mock an entire template file, meaning if you use any macros from it within the macro being tested, they should all be mocked here or they will not be found. But mocking everything but the macro being tested is best practice anyway.

Skipping is straight-forward, it simply involves adding `"skip": true` to the macro test JSON. Internally this moves the creation of the Jinja2 environment into the rendering stage. This has the practical effect of there being separate environments for each macro test, which is also better practice.

@kurtw @dpford @KimberlyMunoz
