### PR TITLE
Specify a BeautifulSoup parser

### DIFF
--- a/macropolo/environments/jinja2_env.py
+++ b/macropolo/environments/jinja2_env.py
@@ -94,6 +94,6 @@ class Jinja2Environment(object):
         test_template = self.env.from_string(test_template_str)
 
         result = test_template.render(self.context)
-        return BeautifulSoup(result)
+        return BeautifulSoup(result, "html.parser")
 
 


### PR DESCRIPTION
This PR specifies the BeautifulSoup HTML parser to silence the warning that’s given without a particular parser.
