### PR TITLE
Allow arguments to be either list or dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ is defined.
 **`skip`**, if true, will skip the macro test. This is optional.
 
 **`arguments`** is a list of arguments to pass to the macro in the order
-they are given. This is optional.
+they are given. Can be either a list or a JSON object of keys/values; if 
+it is a JSON object of keys/values, it is presumed to be keyword 
+arguments. This is optional.
 
 **`keyword_arguments`** is an object containing key/value arguments to pass
 to the macro if it requires keyword arguments. This is optional.

--- a/macropolo/environments/jinja2_env.py
+++ b/macropolo/environments/jinja2_env.py
@@ -94,6 +94,6 @@ class Jinja2Environment(object):
         test_template = self.env.from_string(test_template_str)
 
         result = test_template.render(self.context)
-        return BeautifulSoup(result)
+        return BeautifulSoup(result, "html.parser")
 
 

--- a/macropolo/jsonspec.py
+++ b/macropolo/jsonspec.py
@@ -115,7 +115,15 @@ def JSONSpecTestCaseFactory(name, super_class, json_file, mixins=[]):
             # Render the macro from the macro file with the given
             # arguments
             args = test_dict.get('arguments', [])
+
+            # kwargs can optionally be specified seperately from args
             kwargs = test_dict.get('keyword_arguments', {})
+
+            # If args is a dict it specifies keyword arguments.
+            # Otherwise assume it's a list of arguments.
+            if isinstance(args, dict):
+                kwargs = args
+                args = []
 
             result = self.render_macro(macro_file, macro_name,
                                     *args, **kwargs)


### PR DESCRIPTION
This PR allows the specification of macro arguments as either a list (current behavior) or as a JSON object containing key/value pairs. If it is a JSON object it will be treated as keyword arguments (same as `keyword_arguments`). For example:

```
"arguments": [
    "bar"
]
```

Will call the given macro as `macro(‘bar’)`. 

```
"arguments": {
    “foo”: “bar”
},
```

Will call the given macro as `macro(foo=‘bar’)`. 

`arguments` and `keyword_arguments` can still be specified independently of each other. If `arguments` and `keyword_arguments` are both key/value pairs, `arguments` will override `keyword_arguments`.

This PR includes the commits from #6.
